### PR TITLE
Remove warning during build time for SHA2 algorithms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,10 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftyJWT",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_12)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftyJWT",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_12)
     ],
     products: [

--- a/Sources/SwiftyJWA/HMAC/HMACCryptoSwift.swift
+++ b/Sources/SwiftyJWA/HMAC/HMACCryptoSwift.swift
@@ -22,11 +22,11 @@ extension HMACAlgorithm.Hash {
   var cryptoSwiftVariant: HMAC.Variant {
     switch self {
     case .sha256:
-      return .sha256
+        return .sha2(.sha256)
     case .sha384:
-      return .sha384
+        return .sha2(.sha384)
     case .sha512:
-      return .sha512
+        return .sha2(.sha512)
     }
   }
 }


### PR DESCRIPTION
Hi,

While migrating to Xcode 13, I spotted a warning from the code that is responsible for selecting the SHA2 algorithm.
With the new CryptoSwift update, we shall use ```.sha2(.shaXXX)``` instead of ```.shaXXX```. The old way become deprecated.

In the meantime, I tried to run the unit tests on MacOS and an error is thrown during build time because of the minimum macOS version that currently can be lower that 10.12 (CryptoSwift unsupported before 10.12). I added these requirements in the Package.swift to avoid this error (still supporting the minimum iOS version that is 9, see CryptoSwift's [Package.swift](https://github.com/krzyzanowskim/CryptoSwift/blob/main/Package.swift)). 

Tests are succeeding on both IOS and MacOS.

I am available to update my PR with your feedbacks, have a nice day.